### PR TITLE
Fix open tasks link

### DIFF
--- a/ProjectOpenTasksProfileMenuItem.php
+++ b/ProjectOpenTasksProfileMenuItem.php
@@ -9,30 +9,20 @@ final class ProjectOpenTasksProfileMenuItem extends PhabricatorProfileMenuItem {
 		return 'fa-anchor';
 	}
 
-	public function getDefaultName() {
-		return pht( 'Open Tasks' );
-	}
-
 	public function getMenuItemTypeName() {
 		return pht( 'Link to Open Tasks' );
 	}
 
-	public function canHideMenuItem(
+	public function canAddToObject(
 		PhabricatorProfileMenuItemConfiguration $config
 	) {
 		return true;
 	}
 
-	public function canMakeDefault(
-		PhabricatorProfileMenuItemConfiguration $config
-	) {
-		return false;
-	}
-
 	public function getDisplayName(
 		PhabricatorProfileMenuItemConfiguration $config
 	) {
-		return $this->getDefaultName();
+		return pht( 'Open Tasks' );
 	}
 
 	protected function newMenuItemViewList(


### PR DESCRIPTION
This basically reverts https://github.com/miraheze/phabricator-extensions/commit/0e4473f1e45b4628715cb64bcdb258bb75906f5a. Paladox committed it without realizing that it was dependent on a custom change in the WMF fork of phabricator.